### PR TITLE
서명 동의 댓글에 페이지네이션 기능 추가

### DIFF
--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -10,7 +10,9 @@ const Comment = ({ comment} ) => {
             lineHeight: '25px',
             letterSpacing: '-0.05em',
             padding: '0 20px',
-        }}>
+        }}
+            key={comment.id}
+        >
             <p>{comment.comment}</p>
             <p>-***</p>
         </div>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from '@emotion/styled'
+
+const Container = styled.ul({
+  display: 'flex',
+  flexDirection: 'row',
+  margin: '12px auto',
+})
+
+const Pager = ({ current, total }) => {
+  return (
+    <li>
+      <input type='text' value={current} />
+      <span>/</span>
+      {total}
+    </li>
+  )
+}
+
+const Button = ({ isPrev }) => {
+  return (
+    <li>
+      <button tabIndex={isPrev ? '-1' : '1'}>
+        {isPrev ? '&#60' : '&#62'}
+      </button>
+    </li>
+  )
+}
+
+const Pagination = ({ current, pageSize, total }) => {
+  return (
+    <Container>
+      <Button isPrev={true} />
+      <Pager current={current} total={total} />
+      <Button isPrev={false} />
+    </Container>
+  )
+}
+
+export default Pagination

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,38 +1,36 @@
 import React from 'react'
 import styled from '@emotion/styled'
 
-const Container = styled.ul({
+const Container = styled.div({
   display: 'flex',
   flexDirection: 'row',
   margin: '12px auto',
 })
 
-const Pager = ({ current, total }) => {
+const Pager = ({ current, setCurrent, total }) => {
   return (
-    <li>
-      <input type='text' value={current} />
+    <div>
+      <input type='text' value={current} onChange={({e}) => setCurrent(e.target.value)} />
       <span>/</span>
       {total}
-    </li>
+    </div>
   )
 }
 
-const Button = ({ isPrev }) => {
+const PageButton = ({ isPrev, onClick, disabled }) => {
   return (
-    <li>
-      <button tabIndex={isPrev ? '-1' : '1'}>
-        {isPrev ? '&#60' : '&#62'}
+      <button disabled={disabled} tabIndex={isPrev ? '-1' : '1'} onClick={onClick}>
+        {isPrev ? "<" : ">"}
       </button>
-    </li>
   )
 }
 
-const Pagination = ({ current, pageSize, total }) => {
+const Pagination = ({ current, setCurrent, pageSize, total }) => {
   return (
     <Container>
-      <Button isPrev={true} />
-      <Pager current={current} total={total} />
-      <Button isPrev={false} />
+      <PageButton isPrev={true} onClick={() => setCurrent(current - 1)} disabled={current === 1} />
+      <Pager current={current} setCurrent={setCurrent} total={Math.ceil(total / pageSize)} />
+      <PageButton isPrev={false} onClick={() => setCurrent(current + 1)} disabled={current === Math.ceil(total / pageSize)} />
     </Container>
   )
 }

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -2,35 +2,65 @@ import React from 'react'
 import styled from '@emotion/styled'
 
 const Container = styled.div({
-  display: 'flex',
-  flexDirection: 'row',
+  textAlign: 'center'
+})
+
+const Ul = styled.ul({
+  display: 'inline-block',
   margin: '12px auto',
+})
+
+const Li = styled.li({
+  float: 'left',
+  height: '24px',
+  marginRight: '8px',
+  fontSize: '14px'
+})
+
+const Input = styled.input({
+  height: '100%',
+  padding: '0 6px',
+  border: '1px solid #d9d9d9',
+  borderRadius: '2px',
+  textAlign: 'center',
+  transition: 'border-color .3s',
+})
+
+const Button = styled.button({
+  display: 'block',
+  height: '100%',
+  backgroundColor: 'transparent',
+  border: '0',
 })
 
 const Pager = ({ current, setCurrent, total }) => {
   return (
-    <div>
-      <input type='text' value={current} onChange={({e}) => setCurrent(e.target.value)} />
-      <span>/</span>
+    <Li title={`${current}/${total}`}>
+      <Input size='3' type='text' value={current} onChange={({e}) => setCurrent(e.target.value)} />
+      <span style={{margin: '0 10px 0 5px'}}>/</span>
       {total}
-    </div>
+    </Li>
   )
 }
 
 const PageButton = ({ isPrev, onClick, disabled }) => {
   return (
-      <button disabled={disabled} tabIndex={isPrev ? '-1' : '1'} onClick={onClick}>
+    <Li>
+      <Button disabled={disabled} tabIndex={isPrev ? '-1' : '1'} onClick={onClick}>
         {isPrev ? "<" : ">"}
-      </button>
+      </Button>
+    </Li>
   )
 }
 
 const Pagination = ({ current, setCurrent, pageSize, total }) => {
   return (
     <Container>
-      <PageButton isPrev={true} onClick={() => setCurrent(current - 1)} disabled={current === 1} />
-      <Pager current={current} setCurrent={setCurrent} total={Math.ceil(total / pageSize)} />
-      <PageButton isPrev={false} onClick={() => setCurrent(current + 1)} disabled={current === Math.ceil(total / pageSize)} />
+      <Ul>
+        <PageButton isPrev={true} onClick={() => setCurrent(current - 1)} disabled={current === 1} />
+        <Pager current={current} setCurrent={setCurrent} total={Math.ceil(total / pageSize)} />
+        <PageButton isPrev={false} onClick={() => setCurrent(current + 1)} disabled={current === Math.ceil(total / pageSize)} />
+      </Ul>
     </Container>
   )
 }

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -2,7 +2,8 @@ import React from 'react'
 import styled from '@emotion/styled'
 
 const Container = styled.div({
-  textAlign: 'center'
+  textAlign: 'center',
+  marginBottom: '20px'
 })
 
 const Ul = styled.ul({
@@ -19,7 +20,7 @@ const Li = styled.li({
 
 const Input = styled.input({
   height: '100%',
-  padding: '0 6px',
+  padding: '0 4px',
   border: '1px solid #d9d9d9',
   borderRadius: '2px',
   textAlign: 'center',
@@ -36,7 +37,7 @@ const Button = styled.button({
 const Pager = ({ current, setCurrent, total }) => {
   return (
     <Li title={`${current}/${total}`}>
-      <Input size='3' type='text' value={current} onChange={({e}) => setCurrent(e.target.value)} />
+      <Input size='2' type='text' value={current} onChange={({e}) => setCurrent(e.target.value)} />
       <span style={{margin: '0 10px 0 5px'}}>/</span>
       {total}
     </Li>

--- a/src/pages/api/signs.js
+++ b/src/pages/api/signs.js
@@ -52,6 +52,7 @@ async function sign (req, res) {
     })
 }
 
+// how to add current to argument to messages function?? 
 async function messages (req, res) {
     const db = getDB()
     const collection = db.collection('signs')
@@ -60,7 +61,8 @@ async function messages (req, res) {
     const messages = await collection
         .where('private', '==', false)
         .orderBy('created', 'desc')
-        .limit(30)
+        // .startAt((current - 1) * 30)
+        .limit(5)
         .get()
 
     cache(res)

--- a/src/pages/api/signs.js
+++ b/src/pages/api/signs.js
@@ -54,16 +54,26 @@ async function sign (req, res) {
 
 async function messages (req, res) {
     const { page, pageSize } = req.query
+
     const db = getDB()
     const collection = db.collection('signs')
     // TODO : query concurrent
     const stats = await collection.doc('__stats').get()
-    const messages = await collection
-        .where('private', '==', false)
-        .orderBy('created', 'desc')
-        .limit(parseInt(pageSize))
-        .offset((parseInt(page) - 1) * pageSize)
-        .get()
+
+    const messages = parseInt(pageSize) > 1000 
+    ? await collection
+    .where('private', '==', false)
+    .orderBy('created', 'desc')
+    .limit(1000)
+    .offset((parseInt(page) - 1) * 1000)
+    .get()
+    : await collection
+    .where('private', '==', false)
+    .orderBy('created', 'desc')
+    .limit(parseInt(pageSize))
+    .offset((parseInt(page) - 1) * parseInt(pageSize))
+    .get()
+
 
     cache(res)
     response(res, {

--- a/src/pages/api/signs.js
+++ b/src/pages/api/signs.js
@@ -52,8 +52,8 @@ async function sign (req, res) {
     })
 }
 
-// how to add current to argument to messages function?? 
 async function messages (req, res) {
+    const { page, pageSize } = req.query
     const db = getDB()
     const collection = db.collection('signs')
     // TODO : query concurrent
@@ -61,8 +61,8 @@ async function messages (req, res) {
     const messages = await collection
         .where('private', '==', false)
         .orderBy('created', 'desc')
-        // .startAt((current - 1) * 30)
-        .limit(5)
+        .limit(parseInt(pageSize))
+        .offset((parseInt(page) - 1) * pageSize)
         .get()
 
     cache(res)

--- a/src/pages/result.js
+++ b/src/pages/result.js
@@ -101,14 +101,13 @@ const Floating = styled.div({
     },
 })
 
-
 const Result = () => {
     const [formOpened, setFormOpened] = React.useState(false)
     const [current, setCurrent] = React.useState(1)
 
     const {state} = useGameState()
 
-    const {data: comments} = useSWR('/api/signs')
+    const {data: comments } = useSWR(`/api/signs?page=${current}&pageSize=${5}`)
     const {data: votes_} = useSWR('/api/votes')
 
     const votes = votes_ && [{

--- a/src/pages/result.js
+++ b/src/pages/result.js
@@ -6,6 +6,7 @@ import Hr from 'components/Hr'
 import Form from 'components/Form'
 import Button from 'components/Button'
 import Comments from 'components/Comments'
+import Pagination from 'components/Pagination'
 import Screen from 'components/Screen'
 import Page from 'components/layouts/Page'
 import { useGameState } from 'hooks/game'
@@ -103,6 +104,7 @@ const Floating = styled.div({
 
 const Result = () => {
     const [formOpened, setFormOpened] = React.useState(false)
+    const [current, setCurrent] = React.useState(1)
 
     const {state} = useGameState()
 
@@ -199,6 +201,7 @@ const Result = () => {
                     <>
                         <p>지금까지 <strong>{comments.count}명</strong>이 개정 서명에 참여하였습니다</p>
                         <Comments comments={comments.items} />
+                        <Pagination current={current} setCurrent={setCurrent} pageSize={5} total={comments.count} />
                     </>
                     }
                 </section>


### PR DESCRIPTION
result 페이지의 comment 섹션에 Pagination 컴포넌트를 추가했습니다.
page, pageSize를 /api/signs?page=${page}&pageSize={pageSize}로 받을 수 있도록 했으나, 인자가 들어오지 않았을 경우 예외처리가 필요합니다.

페이지네이션 이동시 스피너를 추가하는 방법이 있을 것 같습니다.
